### PR TITLE
Allow floats for weights

### DIFF
--- a/GIFT.pegjs
+++ b/GIFT.pegjs
@@ -2,9 +2,6 @@
 {
   var defaultFormat = "moodle"; // default format - the GIFT specs say [moodle] is default, but not sure what that means for other applications
   var format = defaultFormat;
-  function makeInteger(o) {
-    return parseInt(o.join(""), 10);
-  }
   function processAnswers(question, answers) {
     question.globalFeedback = answers.globalFeedback;
     switch(question.type) {
@@ -138,10 +135,10 @@ Choice "Choice"
       return choice } 
 
 Weight "(weight)"
-  = '%' percent:([-]? PercentValue) '%' { return makeInteger(percent) }
+  = '%' percent:([-]? PercentValue) '%' { return parseFloat(percent.join('')) }
   
 PercentValue "(percent)"
-  = '100' / [0-9][0-9]?  { return text() }
+  = '100' / [0-9][0-9]?[.]?[0-9]*  { return text() }
 
 Feedback "(feedback)" 
   = '#' !'###' _ feedback:RichText? { return feedback }

--- a/tests/questions/multipleAnswersFloat.gift
+++ b/tests/questions/multipleAnswersFloat.gift
@@ -1,0 +1,7 @@
+Select all of the options below which name a continent\:{
+    ~%33.33333%Africa
+    ~%33.33333%Asia
+    ~%-100%China
+    ~%33.33333%Antarctica
+    ~%-100%America
+}

--- a/tests/questions/multipleAnswersFloat.json
+++ b/tests/questions/multipleAnswersFloat.json
@@ -1,0 +1,59 @@
+[
+    {
+       "type": "MC",
+       "title": null,
+       "stem": {
+          "format": "moodle",
+          "text": "Select all of the options below which name a continent:"
+       },
+       "hasEmbeddedAnswers": false,
+       "globalFeedback": null,
+       "choices": [
+          {
+             "isCorrect": false,
+             "weight": 33.33333,
+             "text": {
+                "format": "moodle",
+                "text": "Africa"
+             },
+             "feedback": null
+          },
+          {
+             "isCorrect": false,
+             "weight": 33.33333,
+             "text": {
+                "format": "moodle",
+                "text": "Asia"
+             },
+             "feedback": null
+          },
+          {
+             "isCorrect": false,
+             "weight": -100,
+             "text": {
+                "format": "moodle",
+                "text": "China"
+             },
+             "feedback": null
+          },
+          {
+             "isCorrect": false,
+             "weight": 33.33333,
+             "text": {
+                "format": "moodle",
+                "text": "Antarctica"
+             },
+             "feedback": null
+          },
+          {
+             "isCorrect": false,
+             "weight": -100,
+             "text": {
+                "format": "moodle",
+                "text": "America"
+             },
+             "feedback": null
+          }
+       ]
+    }
+ ]


### PR DESCRIPTION
Moodle allows floats to be used for percentage weights, which is useful in multiple answer questions. For instance, say we wanted to create a multiple choice question with three correct answers. It would look like the following:

```plain
Select all of the options below which name a continent\:{
    ~%33.33333%Africa
    ~%33.33333%Asia
    ~%-100%China
    ~%33.33333%Antarctica
    ~%-100%America
}
```

These float percentages are also supported by the official Moodle docs:

> Note specifically, that Moodle uses 5 decimal places to do its math, so if you wish to divide percentages in thirds, use %33.33333 instead of %33 or %33.33.

Adding support for floats would help improve the flexibility of these multiple answer questions.