### PR TITLE
Typescript Type Revisions 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,11 +73,11 @@ export type QuestionType =
   | "TF"
   | "Matching";
 
-export type Format = "moodle" | "html" | "markdown" | "plain";
+export type FormatType = "moodle" | "html" | "markdown" | "plain";
 export type NumericalType = "simple" | "range" | "high-low";
 
 export interface TextFormat {
-  format: Format;
+  format: FormatType;
   text: string;
 }
 
@@ -93,7 +93,7 @@ export interface Choice {
   isCorrect: boolean;
   weight: number | null;
   text: TextFormat | NumericalFormat;
-  feedback: Text | null;
+  feedback: TextFormat | null;
 }
 
 interface Question {
@@ -105,45 +105,45 @@ interface Question {
 }
 
 export interface Description {
-  type: Extract<"Description", QuestionType>;
+  type: Extract<QuestionType, "Description">;
   title: string | null;
   stem: TextFormat;
   hasEmbeddedAnswers: boolean;
 }
 
 export interface Category {
-  type: Extract<"Category", QuestionType>;
+  type: Extract<QuestionType, "Category">;
   title: string;
 }
 
 export interface MultipleChoice extends Question {
-  type: Extract<"MC", QuestionType>;
+  type: Extract<QuestionType, "MC">;
   choices: Choice[];
 }
 
 export interface ShortAnswer extends Question {
-  type: Extract<"Short", QuestionType>;
+  type: Extract<QuestionType, "Short">;
   choices: Choice[];
 }
 
 export interface Numerical extends Question {
-  type: Extract<"Numerical", QuestionType>;
-  choices: Choice[];
+  type: Extract<QuestionType, "Numerical">;
+  choices: Choice[] | NumericalFormat;
 }
 
 export interface Essay extends Question {
-  type: Extract<"Essay", QuestionType>;
+  type: Extract<QuestionType, "Essay">;
 }
 
 export interface TrueFalse extends Question {
-  type: Extract<"TF", QuestionType>;
+  type: Extract<QuestionType, "TF">;
   isTrue: boolean;
-  incorrectFeedback: Text | null;
-  correctFeedback: Text | null;
+  incorrectFeedback: TextFormat | null;
+  correctFeedback: TextFormat | null;
 }
 
 export interface Matching extends Question {
-  type: Extract<"Matching", QuestionType>;
+  type: Extract<QuestionType, "Matching">;
   matchPairs: Match[];
 }
 


### PR DESCRIPTION
So I've been testing the typings out in the wild and I had a couple of changes.
1. Fix all instances of the `Text` type and replace with `TextFormat`. This will correct the typings for feedback that were incorrectly typed.
2. Rename `Format` to `FormatType` for consistency.
3. Correct the argument order of the Extract utility for question types. The arguments were the wrong way around the first time.

The other thing I was thinking was whether to rename interface types with the following pattern: `IDescription`, `IMultipleChoice` etc. The upside of this is a lower chance of name clashes when users use the library with capitals (e.g. using `MultipleChoice` or `multipleChoice` as a function name), and better differentiation of types from the library API.